### PR TITLE
lm/ios 14 Video bug fix

### DIFF
--- a/PyrusServiceDeskIOS/PyrusServiceDesk/Chat/LoadAttachments/PSDAttachmentPreviewView.swift
+++ b/PyrusServiceDeskIOS/PyrusServiceDesk/Chat/LoadAttachments/PSDAttachmentPreviewView.swift
@@ -58,7 +58,9 @@ class PSDAttachmentPreviewView: UIView {
             videoPlayer.view.frame = frame
             videoPlayer.videoGravity = .resizeAspect
             addSubview(videoPlayer.view)
-            videoPlayer.player = player
+        }
+        DispatchQueue.main.async() {
+            self.videoPlayer?.player = self.player
         }
     }
     private func showWebView(url: URL){


### PR DESCRIPTION
Исправлен баг на iOS 14 при котором на проигрывании видео не было кнопки плэй