### PR TITLE
Ep/fix/ivi bugs

### DIFF
--- a/PyrusServiceDeskAndroid/pyrusservicedesk/src/main/java/com/pyrus/pyrusservicedesk/PyrusServiceDesk.kt
+++ b/PyrusServiceDeskAndroid/pyrusservicedesk/src/main/java/com/pyrus/pyrusservicedesk/PyrusServiceDesk.kt
@@ -469,15 +469,14 @@ class PyrusServiceDesk private constructor(
 
             this.onStopCallback = onStopCallback
 
-            // The UiInjector is owned by MainActivity (created in its onCreate, released in
-            // its onDestroy). We only schedule activity launch here; nothing UI-related is
-            // touched on whatever thread `start()` was called from.
-            ThreadsHelper().syncRunOnMainThread {
-                val startData = StartData(account, openTicketAction, sendComment)
-                val intent = MainActivity.createLaunchIntent(activity, startData)
-                intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                activity.startActivity(intent)
-            }
+            val startData = StartData(account, openTicketAction, sendComment)
+            val intent = MainActivity.createLaunchIntent(activity, startData)
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
+            // start() may be called from any thread. We only bounce the actual activity launch to
+            // the UI thread: runOnUiThread runs inline when already on main and does a NON-blocking
+            // post otherwise.
+            activity.runOnUiThread { activity.startActivity(intent) }
             updateSdIsOpen(true)
 
             injector().updateUserUseCase.updateUser()

--- a/PyrusServiceDeskAndroid/pyrusservicedesk/src/main/java/com/pyrus/pyrusservicedesk/PyrusServiceDesk.kt
+++ b/PyrusServiceDeskAndroid/pyrusservicedesk/src/main/java/com/pyrus/pyrusservicedesk/PyrusServiceDesk.kt
@@ -7,14 +7,8 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.util.Log
 import androidx.annotation.MainThread
-import com.pyrus.pyrusservicedesk.PyrusServiceDesk.Companion.UI_INJECTOR
-import com.pyrus.pyrusservicedesk.PyrusServiceDesk.Companion.onAuthorizationFailed
-import com.pyrus.pyrusservicedesk.PyrusServiceDesk.Companion.releaseUiInjector
 import com.pyrus.pyrusservicedesk.PyrusServiceDesk.Companion.setPushToken
-import com.pyrus.pyrusservicedesk.PyrusServiceDesk.Companion.start
-import com.pyrus.pyrusservicedesk.PyrusServiceDesk.Companion.stop
 import com.pyrus.pyrusservicedesk.SdConstants.PYRUS_BASE_DOMAIN
-import com.pyrus.pyrusservicedesk._ref.helpers.ThreadsHelper
 import com.pyrus.pyrusservicedesk._ref.ui_domain.screens.ticket.MainActivity
 import com.pyrus.pyrusservicedesk._ref.utils.ConfigUtils
 import com.pyrus.pyrusservicedesk._ref.utils.MILLISECONDS_IN_MINUTE
@@ -41,6 +35,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 
 class PyrusServiceDesk private constructor(
@@ -237,16 +232,17 @@ class PyrusServiceDesk private constructor(
             autoRefreshFeatureFactory?.cancel()
             INJECTOR?.onCancel()
 
+            val scope = CoroutineScope(Dispatchers.Main + SupervisorJob() + CoroutineExceptionHandler { _, throwable ->
+                throwable.printStackTrace()
+                Log.e(TAG, "coreScope global error: ${throwable.message}")
+                PLog.e(TAG, "coreScope global error: ${throwable.message}")
+                throwable.printStackTrace()
+            })
             INJECTOR = DiInjector(
                 application = application,
                 initialAccount = newAccount,
                 authToken = authorizationToken,
-                coreScope = CoroutineScope(Dispatchers.Main + SupervisorJob() + CoroutineExceptionHandler { _, throwable ->
-                    throwable.printStackTrace()
-                    Log.e(TAG, "coreScope global error: ${throwable.message}")
-                    PLog.e(TAG, "coreScope global error: ${throwable.message}")
-                    throwable.printStackTrace()
-                }),
+                coreScope = scope,
                 preferences = preferences
             )
 
@@ -257,8 +253,10 @@ class PyrusServiceDesk private constructor(
             }
 
             migratePreferences(application, preferences)
-            if (loggingEnabled) PLog.instantiate(application)
-
+            // Logger setup touches the filesystem (mkdirs + open the log writer). Run it off the
+            // (possibly main) init thread so it can not contribute to a startup ANR; early logs
+            // before it finishes are simply dropped (guarded by StaticRepository.logging).
+            if (loggingEnabled) scope.launch(Dispatchers.IO) { PLog.instantiate(application) }
         }
 
         private fun validateDomain(domain: String?): Boolean {

--- a/PyrusServiceDeskAndroid/pyrusservicedesk/src/main/java/com/pyrus/pyrusservicedesk/_ref/ui_domain/screens/ticket/MainActivity.kt
+++ b/PyrusServiceDeskAndroid/pyrusservicedesk/src/main/java/com/pyrus/pyrusservicedesk/_ref/ui_domain/screens/ticket/MainActivity.kt
@@ -63,7 +63,9 @@ internal class MainActivity : FragmentActivity() {
         binding = PsdActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        WindowCompat.setDecorFitsSystemWindows(window, false)
+        if (VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+        }
 
         savedInstanceState?.let { ServiceDeskConfiguration.restore(it) }
         super.overridePendingTransition(R.anim.fade_in, R.anim.no_animation)

--- a/PyrusServiceDeskAndroid/pyrusservicedesk/src/main/java/com/pyrus/pyrusservicedesk/_ref/ui_domain/screens/ticket/MainActivity.kt
+++ b/PyrusServiceDeskAndroid/pyrusservicedesk/src/main/java/com/pyrus/pyrusservicedesk/_ref/ui_domain/screens/ticket/MainActivity.kt
@@ -63,7 +63,7 @@ internal class MainActivity : FragmentActivity() {
         binding = PsdActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        if (VERSION.SDK_INT > Build.VERSION_CODES.Q) {
+        if (VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             WindowCompat.setDecorFitsSystemWindows(window, false)
         }
 

--- a/PyrusServiceDeskAndroid/pyrusservicedesk/src/main/java/com/pyrus/pyrusservicedesk/_ref/utils/PreferenceUtils.kt
+++ b/PyrusServiceDeskAndroid/pyrusservicedesk/src/main/java/com/pyrus/pyrusservicedesk/_ref/utils/PreferenceUtils.kt
@@ -1,6 +1,5 @@
 package com.pyrus.pyrusservicedesk._ref.utils
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.SharedPreferences
 
@@ -49,19 +48,18 @@ private fun isMigrationRequired(preferences: SharedPreferences): Boolean {
     return MIGRATE_TO_VERSION > preferences.getInt(PREFERENCE_KEY_VERSION, 0)
 }
 
-@SuppressLint("ApplySharedPref")
 private fun toVersion1(context: Context, preferences: SharedPreferences) {
     val legacy = context.getSharedPreferences(PREFERENCE_KEY_LEGACY, Context.MODE_PRIVATE)
+    // apply() (not commit()) so this one-time migration never blocks the calling thread on an
+    // fsync during init(). apply() updates the in-memory values synchronously, so the recursive
+    // isMigrationRequired() check and any later reads still observe the migrated state.
     if (legacy.all?.isEmpty() == false) {
         preferences
             .edit()
             .putString(PREFERENCE_KEY_DRAFT, legacy.getString(PREFERENCE_KEY_DRAFT_LEGACY, ""))
-            .commit()
-        preferences
-            .edit()
             .putString(PREFERENCE_KEY_USER_ID, legacy.getString(PREFERENCE_KEY_USER_ID_LEGACY, ""))
-            .commit()
+            .apply()
         legacy.edit().clear().apply()
     }
-    preferences.edit().putInt(PREFERENCE_KEY_VERSION, 1).commit()
+    preferences.edit().putInt(PREFERENCE_KEY_VERSION, 1).apply()
 }


### PR DESCRIPTION
Столкнулись с рядом проблем после обновления PyrusSDK c 1.8.07 на 1.8.13 на Android:
В новых версиях, ловим ANR при запуске вашего экрана после того как была добавлена принудительная блокировка фонового и переключение на главный поток. В версии 1.8.07 можно было гибко запускать ваш экран из любого потока без блокировок и переключений потоков. Хотели бы вернуть эту возможность в новых версиях и осуществлять инициализацию и запуск вашего процесса/экрана в фоновом потоке.
В новых версиях при загрузке картинки в чат, пропадает поле ввода текста, так же на Android 9+.

---

[#369171673](https://pyrus.com/t#id369171673) Bugs Android: anr при запуске экрана ; Новый